### PR TITLE
Feature check long - now two programs to run and check tests

### DIFF
--- a/tests/auto/auto_expts_list.txt
+++ b/tests/auto/auto_expts_list.txt
@@ -1,0 +1,2 @@
+grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GSD_SAR
+grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16

--- a/tests/auto/auto_expts_list.txt
+++ b/tests/auto/auto_expts_list.txt
@@ -1,2 +1,0 @@
-grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GSD_SAR
-grid_RRFS_CONUS_25km_ics_FV3GFS_lbcs_FV3GFS_suite_GFS_v16

--- a/tests/auto/ci_auto.py
+++ b/tests/auto/ci_auto.py
@@ -5,7 +5,7 @@ Automation of UFS Regression Testing for ufs-weather-model
 This script automates the process of UFS CI for
 code managers at NOAA-EMC
 
-This script should be started through start_ci_auto.sh so that
+This script should be started through start_ci_py_pro.sh so that
 env vars and Python paths are set up prior to start.
 """
 from github import Github as gh
@@ -14,9 +14,12 @@ import datetime
 import subprocess
 import re
 import os
+import sys
 import logging
 from configparser import ConfigParser as config_parser
+from pathlib import Path
 import importlib
+import argparse
 
 
 class GHInterface:
@@ -279,6 +282,15 @@ def main():
                         level=logging.INFO)
     logger = logging.getLogger('MAIN')
     logger.info('Starting Script')
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("testfile",
+                        help="Please provide required tests filename")
+
+    # get the command line arguments
+    args = parser.parse_args()
+    if not Path(args.testfile).is_file():
+        sys.exit("*** Tests file " + args.testfile + " cannot be found!")
 
     # setup environment
     logger.info('Getting the environment setup')

--- a/tests/auto/ci_auto.py
+++ b/tests/auto/ci_auto.py
@@ -14,12 +14,9 @@ import datetime
 import subprocess
 import re
 import os
-import sys
 import logging
 from configparser import ConfigParser as config_parser
-from pathlib import Path
 import importlib
-import argparse
 
 
 class GHInterface:
@@ -282,15 +279,6 @@ def main():
                         level=logging.INFO)
     logger = logging.getLogger('MAIN')
     logger.info('Starting Script')
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("testfile",
-                        help="Please provide required tests filename")
-
-    # get the command line arguments
-    args = parser.parse_args()
-    if not Path(args.testfile).is_file():
-        sys.exit("*** Tests file " + args.testfile + " cannot be found!")
 
     # setup environment
     logger.info('Getting the environment setup')

--- a/tests/auto/ci_long.py
+++ b/tests/auto/ci_long.py
@@ -3,6 +3,9 @@ Name: ci_long.py
 This Python program reads a config file that has information
 on End to End workflow tests that were not completed, and
 returns status information.
+
+This script should be started through start_ci_py_pro.sh so that
+env vars and Python paths are set up prior to start.
 """
 
 from github import Github as gh

--- a/tests/auto/ci_long.py
+++ b/tests/auto/ci_long.py
@@ -1,0 +1,111 @@
+"""
+This Python program reads a config file that has information
+on End to End workflow tests that were not completed.
+"""
+
+from github import Github as gh
+
+import datetime
+import os
+import logging
+from configparser import ConfigParser as config_parser
+
+
+class GHInterface:
+    '''
+    This class stores information for communicating with GitHub
+    ...
+
+    Attributes
+    ----------
+    GHACCESSTOKEN : str
+      API token to authenticate with GitHub
+    client : pyGitHub communication object
+      The connection to GitHub to make API requests
+    '''
+
+    def __init__(self):
+        self.logger = logging.getLogger('GHINTERFACE')
+
+        filename = 'accesstoken'
+
+        if os.path.exists(filename):
+            if oct(os.stat(filename).st_mode)[-3:] != 600:
+                with open(filename) as f:
+                    os.environ['ghapitoken'] = f.readline().strip('\n')
+            else:
+                raise Exception('File permission needs to be "600" ')
+        else:
+            raise FileNotFoundError('Cannot find file "accesstoken"')
+
+        try:
+            self.client = gh(os.getenv('ghapitoken'))
+        except Exception as e:
+            self.logger.critical(f'Exception is {e}')
+            raise(e)
+
+
+def main():
+
+    # handle logging
+    log_filename = f'ci_long_'\
+                   f'{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}.log'
+    logging.basicConfig(filename=log_filename, filemode='w',
+                        level=logging.INFO)
+    logger = logging.getLogger('MAIN')
+    logger.info('Starting Script')
+
+    # setup interface with GitHub
+    logger.info('Setting up GitHub interface.')
+    ghinterface_obj = GHInterface()
+
+    config = config_parser()
+
+    # Read file that has info on uncompleted tests
+
+    file_name = 'Longjob.cfg'
+    if not os.path.exists(file_name):
+        logger.info(f'Could not find {file_name}')
+        raise KeyError(f'Machine config file {file_name} '
+                       'not found. Exiting.')
+
+    config.read(file_name)
+    num_sections = len(config.sections())
+    # Words to search for in log to signal success or failure
+    complete_string = "This cycle is complete"
+    failed_string = "FAILED"
+    expt_done = 0
+
+    for ci_log in config.sections():
+        logger.info(f'{ci_log}: {config[ci_log]["pr_repo"]}')
+        if os.path.exists(ci_log):
+            pr_comment = ''
+            expt = config[ci_log]["expt"]
+            pr_num = int(config[ci_log]["pr_num"])
+            repo = ghinterface_obj.client.get_repo(config[ci_log]["pr_repo"])
+            pr = repo.get_pull(pr_num)
+            with open(ci_log) as fname:
+                for line in fname:
+                    if complete_string in line:
+                        expt_done = expt_done + 1
+                        newtext = f'Experiment Succeeded: {expt}'
+                        pr_comment += f'{newtext}\n'
+                        newtext = f'{line.rstrip()}'
+                        pr_comment += f'{newtext}\n'
+                        logger.info(f'Experiment Succeeded: {expt}')
+                        pr.create_issue_comment(pr_comment)
+                    else:
+                        if failed_string in line:
+                            expt_done = expt_done + 1
+                            newtext = f'Experiment Failed: {expt}'
+                            pr_comment += f'{newtext}\n'
+                            newtext = f'{line.rstrip()}'
+                            pr_comment += f'{newtext}\n'
+                            logger.info(f'Experiment Failed: {expt}')
+                            pr.create_issue_comment(pr_comment)
+
+        logger.info(f'Experiments Completed: {str(expt_done)}')
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/auto/ci_long.py
+++ b/tests/auto/ci_long.py
@@ -70,9 +70,8 @@ def main():
 
     file_name = 'Longjob.cfg'
     if not os.path.exists(file_name):
-        logger.info(f'Could not find {file_name}')
-        raise KeyError(f'Machine config file {file_name} '
-                       'not found. Exiting.')
+        logger.info(f'Could not find {file_name}. Exiting.')
+        quit()
 
     config.read(file_name)
     num_sections = len(config.sections())
@@ -89,6 +88,7 @@ def main():
             pr_comment = ''
             expt_done = False
             expt = config[ci_log]["expt"]
+            machine = config[ci_log]["machine"]
             pr_num = int(config[ci_log]["pr_num"])
             repo = ghinterface_obj.client.get_repo(config[ci_log]["pr_repo"])
             pr = repo.get_pull(pr_num)
@@ -102,7 +102,9 @@ def main():
                             expt_string = "Failed"
                     if expt_string:
                         expt_done = True
-                        newtext = f'Experiment {expt_string}: {expt}'
+                        newtext = f'Experiment {expt_string} '
+                        pr_comment += f'{newtext}'
+                        newtext = f'on {machine}: {expt}'
                         pr_comment += f'{newtext}\n'
                         newtext = f'{line.rstrip()}'
                         pr_comment += f'{newtext}\n'

--- a/tests/auto/ci_long.py
+++ b/tests/auto/ci_long.py
@@ -1,6 +1,8 @@
 """
+Name: ci_long.py
 This Python program reads a config file that has information
-on End to End workflow tests that were not completed.
+on End to End workflow tests that were not completed, and
+returns status information.
 """
 
 from github import Github as gh
@@ -72,7 +74,7 @@ def main():
     config.read(file_name)
     num_sections = len(config.sections())
     logger.info(f'Experiments running: {num_sections}')
-    
+
     # Words to search for in log to signal success or failure
     complete_string = "This cycle is complete"
     failed_string = "FAILED"
@@ -101,13 +103,13 @@ def main():
                         pr_comment += f'{newtext}\n'
                         newtext = f'{line.rstrip()}'
                         pr_comment += f'{newtext}\n'
-                        pr.create_issue_comment(pr_comment)                        
+                        pr.create_issue_comment(pr_comment)
                         logger.info(f'Experiment {expt_string}: {expt}')
             if expt_done:
                 expt_done_count = expt_done_count + 1
                 config.remove_section(ci_log)
     logger.info(f'Experiments Completed: {str(expt_done_count)}')
-    
+
     if expt_done_count == num_sections:
         # Delete the file if all experiments are done
         os.remove(file_name)
@@ -115,6 +117,7 @@ def main():
         # Write out the file with completed experiments removed
         with open(file_name, 'w') as fname:
             config.write(fname)
+
 
 if __name__ == '__main__':
     main()

--- a/tests/auto/jobs/build.py
+++ b/tests/auto/jobs/build.py
@@ -22,6 +22,8 @@ def run(job_obj):
     os.environ['SR_WX_APP_TOP_DIR'] = pr_repo_loc
     build_script_loc = pr_repo_loc + '/test'
     log_name = 'build.out'
+    # machine passed twoce to work with both build script versions:
+    # passing in machine, and not erroring for only one arg
     create_build_commands = [[f'./build.sh {job_obj.machine} '
                               f'{job_obj.machine} >& {log_name}',
                              build_script_loc]]

--- a/tests/auto/jobs/build.py
+++ b/tests/auto/jobs/build.py
@@ -22,7 +22,7 @@ def run(job_obj):
     os.environ['SR_WX_APP_TOP_DIR'] = pr_repo_loc
     build_script_loc = pr_repo_loc + '/test'
     log_name = 'build.out'
-    # machine passed twoce to work with both build script versions:
+    # machine passed twice to work with both build script versions:
     # passing in machine, and not erroring for only one arg
     create_build_commands = [[f'./build.sh {job_obj.machine} '
                               f'{job_obj.machine} >& {log_name}',

--- a/tests/auto/jobs/build.py
+++ b/tests/auto/jobs/build.py
@@ -22,7 +22,8 @@ def run(job_obj):
     os.environ['SR_WX_APP_TOP_DIR'] = pr_repo_loc
     build_script_loc = pr_repo_loc + '/test'
     log_name = 'build.out'
-    create_build_commands = [[f'./build.sh {job_obj.machine} >& {log_name}',
+    create_build_commands = [[f'./build.sh {job_obj.machine} '
+                              f'{job_obj.machine} >& {log_name}',
                              build_script_loc]]
     logger.info('Running test build script')
     job_obj.run_commands(logger, create_build_commands)
@@ -36,7 +37,7 @@ def run(job_obj):
             expt_script_loc = pr_repo_loc + '/regional_workflow/tests/WE2E'
             expts_base_dir = os.path.join(repo_dir_str, 'expt_dirs')
             log_name = 'expt.out'
-            we2e_script = expt_script_loc + '/end_to_end_tests.sh'
+            we2e_script = expt_script_loc + '/setup_WE2E_tests.sh'
             if os.path.exists(we2e_script):
                 logger.info('Running end to end test')
                 create_expt_commands = \

--- a/tests/auto/start_ci_auto.sh
+++ b/tests/auto/start_ci_auto.sh
@@ -1,6 +1,8 @@
 #!/bin/bash --login
 set -eux
 
+pypro = $1
+
 if [[ $HOSTNAME == hfe* ]]; then
   module use -a /contrib/miniconda3/modulefiles
   module load miniconda3
@@ -26,6 +28,6 @@ else
   exit 1
 fi
 
-python ci_auto.py
+python ${pypro}
 
 exit 0

--- a/tests/auto/start_ci_py_pro.sh
+++ b/tests/auto/start_ci_py_pro.sh
@@ -1,0 +1,63 @@
+#!/bin/bash --login
+set -eux
+
+#----------------------------------------------------------------------
+# This script loads the correct Python module for an HPC,
+# then runs the Python program given as the second parameter.
+#----------------------------------------------------------------------
+
+function usage {
+  echo
+  echo "Usage: $0 machine py_prog | -h"
+  echo
+  echo "       machine       [required] is one of: ${machines[@]}"
+  echo "       py_prog       [required] Python program to run"
+  echo "       test_list     [optional] List of tests for ci_auto.py"
+  echo "                     default is auto_expts_list.txt - 2 tests"
+  echo "       -h            display this help"
+  echo
+  return 1
+
+}
+
+machines=( "hera jet" )
+
+[[ $# -lt 2 ]] && usage 
+if [ "$1" = "-h" ] ; then usage ; fi
+
+export machine=$1
+machine=$(echo "${machine}" | tr '[A-Z]' '[a-z]')  # need lower case machine name
+
+export py_prog=$2
+
+if [[ $# -lt 3 ]] ; then
+   export test_list="auto_expts_list.txt"
+else
+   export test_list=$3
+fi
+
+if [[ ${py_prog} == "ci_auto.py" ]] ; then
+   if [ ! -f ${test_list} ]; then
+     echo "Test list file ${test_list} does not exist."
+     exit 1
+   fi
+   export py_prog="${py_prog} ${test_list}"
+fi
+
+if [[ ${machine} == hera ]]; then
+  module use -a /contrib/miniconda3/modulefiles
+  module load miniconda3
+  conda activate github_auto
+elif [[  ${machine} == jet ]]; then
+  # left in this format in case hera and jet diverge
+  module use -a /contrib/miniconda3/modulefiles
+  module load miniconda3
+  conda activate github_auto
+else
+  echo "No Python Path for machine ${machine}."
+  exit 1
+fi
+
+python ${py_prog}
+
+exit 0

--- a/tests/auto/start_ci_py_pro.sh
+++ b/tests/auto/start_ci_py_pro.sh
@@ -23,10 +23,10 @@ machines=( "hera jet" )
 [[ $# -lt 2 ]] && usage 
 if [ "$1" = "-h" ] ; then usage ; fi
 
-export machine=$1
+machine=$1
 machine=$(echo "${machine}" | tr '[A-Z]' '[a-z]')  # need lower case machine name
 
-export py_prog=$2
+py_prog=$2
 
 if [[ ${machine} == hera ]]; then
   module use -a /contrib/miniconda3/modulefiles

--- a/tests/auto/start_ci_py_pro.sh
+++ b/tests/auto/start_ci_py_pro.sh
@@ -1,5 +1,5 @@
 #!/bin/bash --login
-set -eux
+set -eu
 
 #----------------------------------------------------------------------
 # This script loads the correct Python module for an HPC,
@@ -12,8 +12,6 @@ function usage {
   echo
   echo "       machine       [required] is one of: ${machines[@]}"
   echo "       py_prog       [required] Python program to run"
-  echo "       test_list     [optional] List of tests for ci_auto.py"
-  echo "                     default is auto_expts_list.txt - 2 tests"
   echo "       -h            display this help"
   echo
   return 1
@@ -29,20 +27,6 @@ export machine=$1
 machine=$(echo "${machine}" | tr '[A-Z]' '[a-z]')  # need lower case machine name
 
 export py_prog=$2
-
-if [[ $# -lt 3 ]] ; then
-   export test_list="auto_expts_list.txt"
-else
-   export test_list=$3
-fi
-
-if [[ ${py_prog} == "ci_auto.py" ]] ; then
-   if [ ! -f ${test_list} ]; then
-     echo "Test list file ${test_list} does not exist."
-     exit 1
-   fi
-   export py_prog="${py_prog} ${test_list}"
-fi
 
 if [[ ${machine} == hera ]]; then
   module use -a /contrib/miniconda3/modulefiles


### PR DESCRIPTION
The goal is to set up 2 cron jobs - one (ci_auto.py) to check labels and kick off the testing workflows, and one (ci_long.py) to check and report on the status of workflows when they complete. One bash shell can start either, setting up python correctly.

The build.sh script in the ufs-srweather-app was changed to not take the machine as an argument, but to determine the machine - making that script less portable. It also has a line to end if there is exactly 1 argument. I call build.sh in build.py with 2 arguments - the machine name twice. So it works now, and will work if build.sh is changed to take the machine name again.