### PR TITLE
Added automation for Gsi regression tests

### DIFF
--- a/tests/auto/ci_auto.py
+++ b/tests/auto/ci_auto.py
@@ -2,6 +2,8 @@
 Revising this Python program to use for WE2E testing. It is based on:
 Automation of UFS Regression Testing for ufs-weather-model
 
+Oct 2022 - adding code to also automate GSI regression tests
+
 This script automates the process of UFS CI for
 code managers at NOAA-EMC
 
@@ -125,8 +127,12 @@ class Job:
                  repo):
         self.logger = logging.getLogger('JOB')
         self.preq_dict = preq_dict
-        # both build and WE2E tests call same module
-        self.job_mod = importlib.import_module('jobs.build')
+        # both SRWA build and WE2E tests call same module build.py
+        # GSI regression tests call regr.py
+        if self.preq_dict["action"] == "rt":
+            self.job_mod = importlib.import_module('jobs.regr')
+        else:
+            self.job_mod = importlib.import_module('jobs.build')
         self.ghinterface_obj = ghinterface_obj
         self.machine = machine_dict['machine']
         self.compiler = compiler
@@ -267,7 +273,7 @@ def setup_env():
             repo_dict.append(one_repo)
 
     # Approved Actions
-    action_list = ['build', 'WE']
+    action_list = ['build', 'WE', 'rt']
 
     return machine_dict, repo_dict, action_list
 

--- a/tests/auto/jobs/regr.py
+++ b/tests/auto/jobs/regr.py
@@ -102,10 +102,6 @@ def clone_pr_repo(job_obj, workdir):
     # copy any extra or revised files needed
     logger.info('Starting file copies')
     create_repo_commands = [[f'cp -r {workdir}/vlab/GSI/fix/* fix/.',
-                             pr_repo_loc],
-                            [f'cp -r {workdir}/gsia/regression/regression_var.sh regression/.',
-                             pr_repo_loc],
-                            [f'cp -r {workdir}/gsia/regression/regression_driver.sh regression/.',
                              pr_repo_loc]]
     job_obj.run_commands(logger, create_repo_commands)
 

--- a/tests/auto/jobs/regr.py
+++ b/tests/auto/jobs/regr.py
@@ -1,7 +1,7 @@
 """
-Name: build.py
-Python to clone and build a repo and if requested run
-End to End workflow tests.
+Name: regr.py
+Python to clone and build a GSI repo and run
+regression tests.
 """
 
 # Imports
@@ -14,77 +14,49 @@ from configparser import ConfigParser as config_parser
 
 def run(job_obj):
     """
-    Runs a CI test for a PR
+    Runs a regression test for a GSI PR
     """
-    logger = logging.getLogger('BUILD/RUN')
+    logger = logging.getLogger('REGR/RUN')
     pr_repo_loc, repo_dir_str = clone_pr_repo(job_obj, job_obj.workdir)
-    # Setting this for the tests/build.sh script
-    os.environ['SR_WX_APP_TOP_DIR'] = pr_repo_loc
-    build_script_loc = pr_repo_loc + '/tests'
+    # Setting this for local testing
+    os.environ['config_path'] = job_obj.workdir
+    build_script_loc = pr_repo_loc + '/ush'
     log_name = 'build.out'
     # passing in machine for build
-    create_build_commands = [[f'./build.sh {job_obj.machine} {job_obj.compiler}'
+    create_build_commands = [['module purge', pr_repo_loc],
+                             [f'module use modulefiles;module load gsi_{job_obj.machine}.{job_obj.compiler}',
+                              pr_repo_loc],
+                             [f'./build.sh ../ '
                               f' >& {log_name}',
                              build_script_loc]]
     logger.info('Running test build script')
     job_obj.run_commands(logger, create_build_commands)
     # Read the build log to see whether it succeeded
-    build_success = post_process(job_obj, build_script_loc, log_name)
+    build_success = post_process(job_obj, build_script_loc, log_name,
+                                 pr_repo_loc)
     logger.info('After build post-processing')
     logger.info(f'Action: {job_obj.preq_dict["action"]}')
     # Comments have not yet been written
     issue_id = 0
     if build_success:
         job_obj.comment_append('Build was Successful')
-        if job_obj.preq_dict["action"] == 'WE':
-            # See if a previous job on same PR is still running
-            cfg_file = 'Longjob.cfg'
-            # See if there are any tests already running for this PR
-            if os.path.exists(cfg_file):
-                config = config_parser()
-                config.read(cfg_file)
-                num_sections = len(config.sections())
-                num_tests = 0
-                # Remove any older tests with the same PR ID
-                for ci_log in config.sections():
-                    if str(job_obj.preq_dict["preq"].id) in ci_log:
-                        num_tests = num_tests + 1
-                        config.remove_section(ci_log)
-                # If those were the only tests, delete the file
-                if num_sections == num_tests:
-                    os.remove(cfg_file)
-                    # Still need to remove cron jobs and maybe output dirs
-                    # Maybe write a message to PR (older issue id)
-            # Start the workflow process
-            expt_script_loc = pr_repo_loc + '/tests/WE2E'
-            expts_base_dir = os.path.join(repo_dir_str, 'expt_dirs')
-            log_name = 'expt.out'
-            we2e_script = expt_script_loc + '/setup_WE2E_tests.sh'
-            if os.path.exists(we2e_script):
-                logger.info('Running end to end test')
-                create_expt_commands = \
-                    [[f'./setup_WE2E_tests.sh {job_obj.machine} '
-                      f'{job_obj.hpc_acc} {job_obj.compiler} >& '
-                      f'{log_name}', expt_script_loc]]
-                job_obj.run_commands(logger, create_expt_commands)
-                logger.info('After end_to_end script')
-                # no experiment dir or no test dirs in it suggests error
-                if os.path.exists(expts_base_dir) and \
-                   len(os.listdir(expts_base_dir)):
-                    job_obj.comment_append('Rocoto jobs started')
-                    # If workflow running, comments will be written
-                    issue_id = process_expt(job_obj, expts_base_dir)
-                else:
-                    setup_log = os.path.join(expt_script_loc, log_name)
-                    if os.path.exists(setup_log):
-                        process_setup(job_obj, setup_log)
-                    gen_log_loc = pr_repo_loc + '/ush'
-                    gen_log_name = 'log.generate_FV3LAM_wflow'
-                    process_gen(job_obj, gen_log_loc, gen_log_name)
-            else:
-                job_obj.comment_append(f'Script {we2e_script} '
-                                       'does not exist in repo')
-                job_obj.comment_append('Cannot run WE2E tests')
+        if job_obj.preq_dict["action"] == 'rt':
+            logger.info('Running GSI regression test')
+            log_name = 'gsi_ctest.out'
+            ctest_loc = pr_repo_loc + '/build/regression'
+            create_regr_commands = \
+                [[f'ctest --verbose >& '
+                  f'{log_name}', ctest_loc]]
+            job_obj.run_commands(logger, create_regr_commands)
+            logger.info('After GSI regression test')
+            ci_log = f'{ctest_loc}/{log_name}'
+            error_strings = ['Test #', 'Test  #', 'ed the', 'Thus',
+                             'resulting', 'job has']
+            if os.path.exists(ci_log):
+                with open(ci_log) as fname:
+                    for line in fname:
+                        if any(x in line for x in error_strings):
+                            job_obj.comment_append(f'{line.rstrip().replace("#", "")}')
     else:
         job_obj.comment_append('Build Failed')
 
@@ -96,16 +68,14 @@ def run(job_obj):
 
 def clone_pr_repo(job_obj, workdir):
     ''' clone the GitHub pull request repo, via command line '''
-    logger = logging.getLogger('BUILD/CLONE_PR_REPO')
+    logger = logging.getLogger('REGR/CLONE_PR_REPO')
 
     # These are for the new/head repo in the PR
-    new_name = job_obj.preq_dict['preq'].head.repo.name
     new_repo = job_obj.preq_dict['preq'].head.repo.full_name
     new_branch = job_obj.preq_dict['preq'].head.ref
     # These are for the default app repo that goes with the workflow
     try:
         auth_repo = job_obj.repo["app_address"]
-        auth_branch = job_obj.repo["app_branch"]
     except Exception as e:
         logger.info('Error getting app address and branch from config dict')
         job_obj.job_failed(logger, 'clone_pr_repo', exception=e)
@@ -113,26 +83,12 @@ def clone_pr_repo(job_obj, workdir):
     # The new repo is the default repo
     git_url = f'https://${{ghapitoken}}@github.com/{new_repo}'
 
-    # If the new repo is the regional workflow (not the app)
-    if new_name != app_name:
-        # look for a matching app repo/branch
-        app_repo = os.path.join(job_obj.preq_dict['preq'].head.user.login,
-                                app_name)
-        branch_list = list(job_obj.ghinterface_obj.client.get_repo(app_repo)
-                           .get_branches())
-        if new_branch in [branch.name for branch in branch_list]:
-            git_url = f'https://${{ghapitoken}}@github.com/{app_repo}'
-            app_branch = new_branch
-        else:
-            git_url = f'https://${{ghapitoken}}@github.com/{auth_repo}'
-            app_branch = auth_branch
-    else:
-        app_branch = new_branch
+    app_branch = new_branch
 
     logger.info(f'GIT URL: {git_url}')
     logger.info(f'app branch: {app_branch}')
     logger.info('Starting repo clone')
-    repo_dir_str = f'{workdir}/'\
+    repo_dir_str = f'{workdir}/pr/'\
                    f'{str(job_obj.preq_dict["preq"].id)}/'\
                    f'{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}'
     pr_repo_loc = f'{repo_dir_str}/{app_name}'
@@ -143,77 +99,31 @@ def clone_pr_repo(job_obj, workdir):
         [f'git clone -b {app_branch} {git_url}', repo_dir_str]]
     job_obj.run_commands(logger, create_repo_commands)
 
-    # Set up configparser to read and update Externals.cfg ini/config file
-    # to change one repo to match the head of the code in the PR
-    config = config_parser()
-    file_name = 'Externals.cfg'
-    file_path = os.path.join(pr_repo_loc, file_name)
-
-    if not os.path.exists(file_path):
-        logger.info(f'Could not find {file_path}')
-        raise FileNotFoundError
-
-    # Only update Externals.cfg for a PR on a regional workflow
-    if new_name != app_name:
-        config.read(file_path)
-        updated_section = new_name
-        logger.info(f'updated section: {updated_section}')
-        new_repo = "https://github.com/" + \
-            job_obj.preq_dict['preq'].head.repo.full_name
-        logger.info(f'new repo: {new_repo}')
-
-        if config.has_section(updated_section):
-
-            config.set(updated_section, 'hash',
-                       job_obj.preq_dict['preq'].head.sha)
-            config.set(updated_section, 'repo_url', new_repo)
-            # Can only have one of hash, branch, tag
-            if config.has_option(updated_section, 'branch'):
-                config.remove_option(updated_section, 'branch')
-            if config.has_option(updated_section, 'tag'):
-                config.remove_option(updated_section, 'tag')
-            # open existing Externals.cfg to update it
-            with open(file_path, 'w') as fname:
-                config.write(fname)
-        else:
-            logger.info('No section {updated_section} in Externals.cfg')
-
-    # call manage externals to get other repos
-    logger.info('Starting manage externals')
-    create_repo_commands = [['./manage_externals/checkout_externals',
+    # copy any extra or revised files needed
+    logger.info('Starting file copies')
+    create_repo_commands = [[f'cp -r {workdir}/vlab/GSI/fix/* fix/.',
+                             pr_repo_loc],
+                            [f'cp -r {workdir}/gsia/regression/regression_var.sh regression/.',
+                             pr_repo_loc],
+                            [f'cp -r {workdir}/gsia/regression/regression_driver.sh regression/.',
                              pr_repo_loc]]
-
     job_obj.run_commands(logger, create_repo_commands)
 
     logger.info('Finished repo clone')
     return pr_repo_loc, repo_dir_str
 
 
-def post_process(job_obj, build_script_loc, log_name):
-    logger = logging.getLogger('BUILD/POST_PROCESS')
+def post_process(job_obj, build_script_loc, log_name, pr_repo_loc):
+    logger = logging.getLogger('REGR/POST_PROCESS')
     ci_log = f'{build_script_loc}/{log_name}'
-    logfile_pass = process_logfile(job_obj, ci_log)
-    logger.info('Build log file was processed')
-
-    return logfile_pass
-
-
-def process_logfile(job_obj, ci_log):
-    """
-    Runs after code has been cloned and built
-    Checks to see whether build was successful or failed
-    """
-    logger = logging.getLogger('BUILD/PROCESS_LOGFILE')
-    fail_string = 'FAIL'
-    success_string = 'ALL BUILDS SUCCEEDED'
+    gsi_exe = pr_repo_loc + '/install/bin/gsi.x'
+    enkf_exe = pr_repo_loc + '/install/bin/enkf.x'
     build_succeeded = False
+
     if os.path.exists(ci_log):
-        with open(ci_log) as fname:
-            for line in fname:
-                if fail_string in line:
-                    job_obj.comment_append(f'{line.rstrip()}')
-                elif success_string in line:
-                    build_succeeded = True
+        # were the executables created?
+        if os.path.exists(gsi_exe) and os.path.exists(enkf_exe):
+            build_succeeded = True
         if build_succeeded:
             logger.info('Build was successful')
         else:
@@ -229,32 +139,12 @@ def process_logfile(job_obj, ci_log):
         raise FileNotFoundError
 
 
-def process_setup(job_obj, setup_log):
-    """
-    Runs after setup for a rocoto workflow
-    Checks to see if an error has occurred
-    """
-    logger = logging.getLogger('BUILD/PROCESS_SETUP')
-    error_string = 'ERROR'
-    setup_failed = False
-    with open(setup_log) as fname:
-        for line in fname:
-            if error_string in line:
-                job_obj.comment_append('Setup for Workflow Failed')
-                setup_failed = True
-                logger.info('Setup for workflow failed')
-            if setup_failed:
-                job_obj.comment_append(f'{line.rstrip()}')
-    if setup_failed:
-        raise Exception('Setup for workflow could not complete ')
-
-
 def process_gen(job_obj, gen_log_loc, gen_log_name):
     """
     Runs after a rocoto workflow has been generated
     Checks to see if an error has occurred
     """
-    logger = logging.getLogger('BUILD/PROCESS_GEN')
+    logger = logging.getLogger('REGR/PROCESS_GEN')
     gen_log = f'{gen_log_loc}/{gen_log_name}'
     error_string = 'ERROR'
     error_msg = 'err_msg'
@@ -276,7 +166,7 @@ def process_expt(job_obj, expts_base_dir):
     Assumes that more expt directories can appear after this job has started
     Checks for success or failure for each expt
     """
-    logger = logging.getLogger('BUILD/PROCESS_EXPT')
+    logger = logging.getLogger('REGR/PROCESS_EXPT')
     expt_done = 0
     # wait time for workflow is time_mult * sleep_time seconds
     time_mult = 2


### PR DESCRIPTION
The same auto_ci.py can be used for SRWA and GSI, though the code is running on hera in two separate directories. For GSI, jobs/regr,py is called to run the tests using ctest.

This also adds the change for the test and tests subdirectories being merged, and compiler being passed to build.sh and setup_WE2E_tests.sh.